### PR TITLE
[POC] Use ramdisk for FeatureExtraction output.csv

### DIFF
--- a/expression-tracker/Gemfile
+++ b/expression-tracker/Gemfile
@@ -6,3 +6,6 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 gem "mqtt"
+gem "ramdo"
+
+gem "pry"

--- a/expression-tracker/Gemfile.lock
+++ b/expression-tracker/Gemfile.lock
@@ -1,13 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.3)
+    filesize (0.2.0)
+    method_source (1.0.0)
     mqtt (0.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    ramdo (0.3.2)
+      filesize
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   mqtt
+  pry
+  ramdo
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This is only a proof of concept. It uses a ramdisk (on /tmp) to write/read output.csv to/from.

Of course the ramdisk will be smaller than the filesystem, but the current output.csv setup needs a restart policy anyway. This setup is fast, and automatically cleaned up when the process is done (I hope). I also feel that filesystem read/write can become a bottleneck in combination with other IO-heavy processes that might occur on the running host,  and unnecessary strain/wear on the hardware.