### PR TITLE
Recognize combo action.

### DIFF
--- a/expression-tracker/actor.rb
+++ b/expression-tracker/actor.rb
@@ -29,10 +29,23 @@ end.parse!
 @last_action = Time.now
 @previous_values = {}
 
-@actions = {:AU02 => 'Page_Up', :AU12 => 'Page_Down'}
+@actions = {
+  :DOUBLE_EYEBROW_RAISE => 'Page_Up',
+  :DOUBLE_LIP_PULL => 'Page_Down',
+  :LIP_LIP_BROW => 'Up',
+  :BROW_BROW_LIP => 'Control_L+F4',
+  :ROW_LIP_BROW => 'Control_L+Tab',
+  :LIP_BROW_LIP => 'Control_L+Shift_L+Tab'
+}
+
 @recognizer = Recognizer.new
 @recognizer.register_callback do |action_unit|
-  xdo_key(@actions[action_unit]) 
+  action = @actions[action_unit]
+  if action
+    xdo_key(action)
+  else
+    puts "\n\n#{'-' * 40}\n#{action_unit}\n#{'-' * 40}\n\n"   
+  end
 end
 
 def handle_message(message)

--- a/expression-tracker/lib/recognizer.rb
+++ b/expression-tracker/lib/recognizer.rb
@@ -2,7 +2,8 @@
 
 # Class for identifying OpenFace Action Units
 class Recognizer
-  TIME_INTERVAL = 0.45 # Originally 1.3
+  TIME_INTERVAL = 0.2 # Originally 1.3
+  COMBO_TIMEOUT = 2.0
 
   ACTION_UNITS =  {
     AU01: 'Inner brow raiser',
@@ -25,8 +26,16 @@ class Recognizer
     AU45: 'Blink'
   }.freeze
 
+  COMBOS = {
+    [:AU02, :AU02] => :DOUBLE_EYEBROW_RAISE,
+    [:AU12, :AU12] => :DOUBLE_LIP_PULL,
+    [:AU12, :AU12, :AU02] => :LIP_LIP_BROW,
+    [:AU02, :AU02, :AU12] => :BROW_BROW_LIP,
+  }.freeze
+
   def initialize
     @last_action = 0
+    @combo = []
   end
 
   def register_callback(&block)
@@ -35,19 +44,25 @@ class Recognizer
 
   def recognize(values)
     return unless values['success'] > 0.9 && values['confidence'] > 0.92
-    puts "#{values['AU12_r']} #{values['timestamp'] - @last_action}" if ENV['DEBUG']
-    return unless (values['timestamp'] - @last_action) > TIME_INTERVAL
-
-    if au = action_unit(values)
-      @last_action = values['timestamp']
-      @callback.call au
+    time_since_last_action = values['timestamp'] - @last_action
+    puts "#{values['AU12_r']} #{values['timestamp']} #{time_since_last_action}" if ENV['DEBUG']
+    if @last_action == 0 || time_since_last_action.between?(TIME_INTERVAL, COMBO_TIMEOUT)
+      puts 'action between' if ENV['DEBUG']
+      if au = action_unit(values)
+        puts 'au', au if ENV['DEBUG']
+        @last_action = values['timestamp']
+        @combo << au
+      end
+    elsif time_since_last_action > COMBO_TIMEOUT && !@combo.empty?
+      @callback.call(COMBOS[@combo] || @combo.first)
+      @combo = []
     end
   end
 
   def action_unit(values)
-    if values['AU02_r'] > 3.3
+    if values['AU02_r'] > 3.5
       :AU02
-    elsif values['AU12_r'] > 2.1
+    elsif values['AU12_r'] > 2.5
       :AU12
     end
   end

--- a/expression-tracker/lib/recognizer.rb
+++ b/expression-tracker/lib/recognizer.rb
@@ -2,7 +2,7 @@
 
 # Class for identifying OpenFace Action Units
 class Recognizer
-  TIME_INTERVAL = 0.2 # Originally 1.3
+  TIME_INTERVAL = 0.5 # Originally 1.3
   COMBO_TIMEOUT = 2.0
 
   ACTION_UNITS =  {
@@ -30,11 +30,14 @@ class Recognizer
     %i[AU02 AU02] => :DOUBLE_EYEBROW_RAISE,
     %i[AU12 AU12] => :DOUBLE_LIP_PULL,
     %i[AU12 AU12 AU02] => :LIP_LIP_BROW,
-    %i[AU02 AU02 AU12] => :BROW_BROW_LIP
+    %i[AU02 AU02 AU12] => :BROW_BROW_LIP,
+    %i[AU02 AU12 AU02] => :BROW_LIP_BROW,
+    %i[AU12 AU02 AU12] => :LIP_BROW_LIP
   }.freeze
 
   def initialize
     @last_action = 0
+    @last_timestamp = 0
     @combo = []
   end
 
@@ -44,6 +47,10 @@ class Recognizer
 
   def recognize(values)
     return unless values['success'] > 0.9 && values['confidence'] > 0.92
+
+    # Reset last_action if server was restarted.
+    @last_action = 0 if @last_timestamp > values['timestamp']
+    @last_timestamp = values['timestamp']
 
     time_since_last_action = values['timestamp'] - @last_action
     puts "#{values['AU12_r']} #{values['timestamp']} #{time_since_last_action}" if ENV['DEBUG']

--- a/expression-tracker/spec/combos_spec.rb
+++ b/expression-tracker/spec/combos_spec.rb
@@ -1,0 +1,64 @@
+require 'csv'
+require 'pry'
+require_relative 'spec_helper'
+require_relative '../lib/recognizer'
+
+describe 'combos' do
+  let(:fixtures) { read_fixtures 'webcam_2020-06-18-16-56.csv' }
+
+  it "recognizes a DOUBLE EYEBROW RAISE" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[286..330].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:DOUBLE_EYEBROW_RAISE])
+  end
+
+  it "recognizes another DOUBLE EYEBROW RAISE" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[423..460].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:DOUBLE_EYEBROW_RAISE])
+  end
+
+  it "recognizes a DOUBLE LIP PULL" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[580..620].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:DOUBLE_LIP_PULL])
+  end
+
+  it "recognizes another DOUBLE LIP PULL" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[711..750].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:DOUBLE_LIP_PULL])
+  end
+
+  it "recognizes LIP LIP BROW" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[871..920].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:LIP_LIP_BROW])
+  end
+
+  it "recognizes another LIP LIP BROW" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[1017..1070].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:LIP_LIP_BROW])
+  end
+
+  it "recognizes BROW BROW LIP" do
+    recognizer = Recognizer.new
+    result = []
+    recognizer.register_callback { |b| result <<  b }
+    fixtures[1171..1220].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:BROW_BROW_LIP])
+  end
+end

--- a/expression-tracker/spec/single_action_spec.rb
+++ b/expression-tracker/spec/single_action_spec.rb
@@ -3,27 +3,13 @@ require 'pry'
 require_relative 'spec_helper'
 require_relative '../lib/recognizer'
 
-module Helpers
-  def read_fixtures filename
-    path = File.join(File.dirname(__FILE__), 'fixtures', filename)
-    keys = CSV.open(path, &:readline).map(&:strip)
-    fixtures = CSV.read(path, { converters: :numeric})
-    fixtures.shift
-    fixtures.map {|a| Hash[ keys.zip(a) ] }
-  end
-end
-
-RSpec.configure do |c|
-  c.include Helpers
-end
-
 describe 'single actions' do
   it "recognizes a eyebrow raise" do
     fixtures = read_fixtures 'mixed.csv'
     recognizer = Recognizer.new
     result = []
     recognizer.register_callback { |b| result << b }
-    fixtures[230..246].each { |frame| recognizer.recognize(frame) }
+    fixtures[230..270].each { |frame| recognizer.recognize(frame) }
     expect(result).to eq([:AU02])
   end
 
@@ -32,7 +18,7 @@ describe 'single actions' do
     recognizer = Recognizer.new
     result = []
     recognizer.register_callback { |b| result << b }
-    fixtures[269..283].each { |frame| recognizer.recognize(frame) }
+    fixtures[269..300].each { |frame| recognizer.recognize(frame) }
     expect(result).to eq([:AU12])
   end
 
@@ -41,8 +27,8 @@ describe 'single actions' do
     recognizer = Recognizer.new
     result = []
     recognizer.register_callback { |b| result << b }
-    fixtures[292..314].each { |frame| recognizer.recognize(frame) }
-    expect(result).to eq([:AU12, :AU12, :AU02])
+    fixtures[292..340].each { |frame| recognizer.recognize(frame) }
+    expect(result).to eq([:LIP_LIP_BROW])
   end
 
   it "does not recognize weak signal" do

--- a/expression-tracker/spec/spec_helper.rb
+++ b/expression-tracker/spec/spec_helper.rb
@@ -13,6 +13,17 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+module Helpers
+  def read_fixtures filename
+    path = File.join(File.dirname(__FILE__), 'fixtures', filename)
+    keys = CSV.open(path, &:readline).map(&:strip)
+    fixtures = CSV.read(path, { converters: :numeric})
+    fixtures.shift
+    fixtures.map {|a| Hash[ keys.zip(a) ] }
+  end
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -97,4 +108,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.include Helpers
 end


### PR DESCRIPTION
Right now, I push the actions on a stack. After COMBO_TIMEOUT I check if we recognised any combo and return it. Otherwise, I just return the first action. I got quite far with the combo specs if I stretched the time interval a bit to allow COMBO_TIMEOUT to expire. 

When I started on the 'lip brow lip' combo, it picked up on another action after the combo was done, which means it didn't match. So we now basically have two options:

1) After COMBO_TIMEOUT, we check if any combo is a prefix of our stack (so combo + some other stuff) and use the combo.
2) Return our combo immediately if we find one. This is quicker (no more waiting for COMBO_TIMEOUT), but it means combos cannot be prefixes of other combos.

Of course, we can make combo timeout a lot shorter than 2 seconds, but I wanted to hold the tweaking for later.